### PR TITLE
remoting.context should be false

### DIFF
--- a/example-3.0/server/config.json
+++ b/example-3.0/server/config.json
@@ -3,9 +3,7 @@
   "host": "0.0.0.0",
   "port": 3000,
   "remoting": {
-    "context": {
-      "enableHttpContext": false
-    },
+    "context": false,
     "rest": {
       "normalizeHttpPath": false,
       "xml": false


### PR DESCRIPTION
### Description
Causes Error: 
```
Unhandled error for request POST /api/containers/container1/upload: Error: remoting.context option was removed in version 3.0. See http://loopback.io/doc/en/lb2/Using-current-context.html for more details.
```

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)